### PR TITLE
Correct README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ const selectedType: MediaTypes = MediaTypes.Image;
 // ✅ Accessing the value
 const associatedText: string = MediaTypes.Image;
 
+// ❌ This is not allowed due to type safety
+// const invalidType: MediaTypes = 'image';
 ```
 
  the Enum helps ensure the proper data type and its values.

--- a/README.md
+++ b/README.md
@@ -314,14 +314,9 @@ enum MediaTypes {
 
 const selectedType: MediaTypes = MediaTypes.Image;
 
-// ❌ This is not allowed due to type safety
-// const selectedType2: MediaTypes = MediaTypes.Video;
-
 // ✅ Accessing the value
 const associatedText: string = MediaTypes.Image;
 
-// ❌ This is not allowed due to type safety
-// const invalidType: MediaTypes = 'image';
 ```
 
  the Enum helps ensure the proper data type and its values.


### PR DESCRIPTION
The removed lines below are actually allowed in typescript.

```
// ❌ This is not allowed due to type safety
// const selectedType2: MediaTypes = MediaTypes.Video;

// ❌ This is not allowed due to type safety
// const invalidType: MediaTypes = 'image';
```